### PR TITLE
Add naucse_render dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -32,6 +32,7 @@ Werkzeug = "*"
 GitPython = "*"
 lxml = "*"
 pygments-pytest = "*"
+naucse-render = "<1.0"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ce795b68bc3bd65040fc5615c4d9c80f6e95bb2f2246cf9bd4289de07de377cf"
+            "sha256": "0ef6cc924511923643a57a9b1684d839eb96a7bf2a5ea6a6fd71ed8bd51d5342"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -335,6 +335,14 @@
             ],
             "index": "pypi",
             "version": "==0.8.4"
+        },
+        "naucse-render": {
+            "hashes": [
+                "sha256:38730174ab499182a0a915c210060fceaa0be49ced88677e50865d6365ef9d34",
+                "sha256:66a36b29141d37398a2608e1f9718e850bc36908d1aae653531906b039b3ad58"
+            ],
+            "index": "pypi",
+            "version": "==0.1"
         },
         "nbconvert": {
             "hashes": [


### PR DESCRIPTION
We're making changes to naucse and need to add `naucse_render` to this fork.
(See https://github.com/pyvec/naucse.python.cz/issues/494 and https://github.com/pyvec/naucse.python.cz/pull/505 for all the details.)
